### PR TITLE
Add destination-path argument allowing overriding destination

### DIFF
--- a/cmd/goreadme/main.go
+++ b/cmd/goreadme/main.go
@@ -39,6 +39,7 @@ var (
 
 func init() {
 	flag.StringVar(&cfg.ImportPath, "import-path", "", "Override package import path.")
+	flag.StringVar(&cfg.DestinationPath, "destination-path", "", "Override package destination path.")
 	flag.StringVar(&cfg.Title, "title", "", "Override readme title. Default is package name.")
 	flag.BoolVar(&cfg.RecursiveSubPackages, "recursive", false, "Load docs recursively.")
 	flag.BoolVar(&cfg.Functions, "functions", false, "Write functions section.")
@@ -69,6 +70,26 @@ Flags:
 }
 
 func main() {
+
+	if cfg.DestinationPath != "" {
+		path = cfg.DestinationPath
+		var err error
+		fmt.Println(filepath.Dir(path))
+		if _, err := os.Stat(filepath.Dir(path)); os.IsNotExist(err) {
+			// Make directory recursively if it does not exist
+			err := os.MkdirAll(filepath.Dir(path), 0755)
+			if err != nil {
+				log.Fatalf("Failed creating folders %s: %s", path, err)
+			}
+		}
+
+		out, err = os.Create(path)
+		if err != nil {
+			log.Fatalf("Failed opening file %s: %s", path, err)
+		}
+		defer out.Close()
+	}
+
 	// Steps to do only in Github Action mode.
 	if path != "" {
 		// Setup output file.
@@ -122,6 +143,16 @@ func main() {
 }
 
 func pkg(args []string) string {
+
+	if cfg.ImportPath != "" {
+		path, err := filepath.Abs("./")
+		if err != nil {
+			log.Fatal(err)
+		}
+		gosrc.SetLocalDevMode(path)
+		return cfg.ImportPath
+	}
+
 	if len(args) > 0 {
 		return args[0]
 	}

--- a/goreadme.go
+++ b/goreadme.go
@@ -129,6 +129,8 @@ type Config struct {
 	// ImportPath is used to override the import path. For example: github.com/user/project,
 	// github.com/user/project/package or github.com/user/project/version.
 	ImportPath string `json:"import_path"`
+	// DestinationPath will be where README.md will be written
+	DestinationPath string `json:"destination_path"`
 	// Functions will make functions documentation to be added to the README.
 	Functions bool `json:"functions"`
 	// Types will make types documentation to be added to the README.


### PR DESCRIPTION
Add "destination-path" option to allow picking the destination of all the generated readme files.

This allows saving all the documentation in a subfolder like `docs` inside a repository.
Example `goreadme -import-path=. -destination-path=docs/README.md`
Will generate `docs/README.md` instead of `README.md`