### PR TITLE
Converting master -> main

### DIFF
--- a/.github/workflows/goaction.yml
+++ b/.github/workflows/goaction.yml
@@ -3,9 +3,6 @@ on:
       branches: [master]
     push:
       branches: [master]
-permissions:
-  # Goaction needs permissions to update pull requests comments.
-  pull-requests: write
 jobs:
     goaction:
       runs-on: ubuntu-latest

--- a/.github/workflows/goaction.yml
+++ b/.github/workflows/goaction.yml
@@ -3,6 +3,9 @@ on:
       branches: [master]
     push:
       branches: [master]
+permissions:
+  # Goaction needs permissions to update pull requests comments.
+  pull-requests: write      
 jobs:
     goaction:
       runs-on: ubuntu-latest

--- a/.github/workflows/goreadme.yml
+++ b/.github/workflows/goreadme.yml
@@ -3,6 +3,9 @@ on:
     branches: [master]
   push:
     branches: [master]
+permissions:
+  # Goreadme needs permissions to update pull requests comments.
+  pull-requests: write    
 jobs:
     goreadme:
         runs-on: ubuntu-latest

--- a/.github/workflows/goreadme.yml
+++ b/.github/workflows/goreadme.yml
@@ -3,9 +3,6 @@ on:
     branches: [master]
   push:
     branches: [master]
-permissions:
-  # Goreadme needs permissions to update pull requests comments.
-  pull-requests: write
 jobs:
     goreadme:
         runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ See [./action.yml](./action.yml) for all available input options.
 ```go
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 jobs:
     goreadme:
         runs-on: ubuntu-latest

--- a/goreadme.go
+++ b/goreadme.go
@@ -16,9 +16,12 @@
 //
 //  on:
 //    push:
-//      branches: [master]
+//      branches: [main]
 //    pull_request:
-//      branches: [master]
+//      branches: [main]
+//  permissions:
+//    # Goreadme needs permissions to update pull requests comments.
+//    pull-requests: write
 //  jobs:
 //      goreadme:
 //          runs-on: ubuntu-latest

--- a/goreadme.go
+++ b/goreadme.go
@@ -5,9 +5,9 @@
 // Github Action
 //
 // Github actions can be configured to update the README file automatically every time it is needed.
-// Below there is an example that on every time a new change is pushed to the master branch, the
+// Below there is an example that on every time a new change is pushed to the main branch, the
 // action is trigerred, generates a new README file, and if there is a change - commits and pushes
-// it to the master branch. In pull requests that affect the README content, if the `github-token`
+// it to the main branch. In pull requests that affect the README content, if the `github-token`
 // is given, the action will post a comment on the pull request with changes that will be made to
 // the README file.
 //
@@ -19,9 +19,6 @@
 //      branches: [master]
 //    pull_request:
 //      branches: [master]
-//  permissions:
-//    # Goreadme needs permissions to update pull requests comments.
-//    pull-requests: write
 //  jobs:
 //      goreadme:
 //          runs-on: ubuntu-latest


### PR DESCRIPTION
Feel free to ignore this, but since github changed the default branch from master to main, newer repos trying to copy the example will fail. Had this happen to me.