### PR TITLE
Fix typo "variabless"

### DIFF
--- a/cmd/goreadme/main.go
+++ b/cmd/goreadme/main.go
@@ -49,7 +49,7 @@ func init() {
 	flag.StringVar(&cfg.Title, "title", "", "Override readme title. Default is package name.")
 	flag.BoolVar(&cfg.RecursiveSubPackages, "recursive", false, "Load docs recursively.")
 	flag.BoolVar(&cfg.Consts, "constants", false, "Write package constants section, and if 'types' is specified, also write per-type constants section.")
-	flag.BoolVar(&cfg.Vars, "variabless", false, "Write package variables section, and if 'types' is specified, also write per-type variables section.")
+	flag.BoolVar(&cfg.Vars, "variables", false, "Write package variables section, and if 'types' is specified, also write per-type variables section.")
 	flag.BoolVar(&cfg.Functions, "functions", false, "Write functions section.")
 	flag.BoolVar(&cfg.Types, "types", false, "Write types section.")
 	flag.BoolVar(&cfg.Factories, "factories", false, "If 'types' is specified, write section for functions returning each type.")


### PR DESCRIPTION
Just a simple typo fix of the `-variabless` flag (double `s`).