### PR TITLE
Allow to disable Ellipsis in types

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@
 
 ---
 
-⚠️ Since the original repo seems inactive, I decided to maintain a fork here, with the changes I wanted.  
+⚠️ Since the [original repo](https://github.com/posener/goreadme) seems inactive, I decided to maintain a fork here, with the changes I wanted.  
 My PRs are also [open on the main repo](https://github.com/posener/goreadme/pulls/alexandregv).
+
+Original work by [Eyal Posener](https://github.com/posener).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@
 [![codecov](https://codecov.io/gh/posener/goreadme/branch/master/graph/badge.svg)](https://codecov.io/gh/posener/goreadme)
 [![GoDoc](https://img.shields.io/badge/pkg.go.dev-doc-blue)](http://pkg.go.dev/github.com/posener/goreadme)
 
+---
+
+⚠️ Since the original repo seems inactive, I decided to maintain a fork here, with the changes I wanted.  
+My PRs are also [open on the main repo](https://github.com/posener/goreadme/pulls/alexandregv).
+
+---
+
 Package goreadme generates readme markdown file from go doc.
 
 The package can be used as a command line tool and as Github action, described below:

--- a/cmd/goreadme/main.go
+++ b/cmd/goreadme/main.go
@@ -50,7 +50,7 @@ func init() {
 	flag.BoolVar(&cfg.RecursiveSubPackages, "recursive", false, "Load docs recursively.")
 	flag.BoolVar(&cfg.Ellipsis, "ellipsis", true, "If 'types' is specified, replace types content with an ellipsis.")
 	flag.BoolVar(&cfg.Consts, "constants", false, "Write package constants section, and if 'types' is specified, also write per-type constants section.")
-	flag.BoolVar(&cfg.Vars, "variabless", false, "Write package variables section, and if 'types' is specified, also write per-type variables section.")
+	flag.BoolVar(&cfg.Vars, "variables", false, "Write package variables section, and if 'types' is specified, also write per-type variables section.")
 	flag.BoolVar(&cfg.Functions, "functions", false, "Write functions section.")
 	flag.BoolVar(&cfg.Types, "types", false, "Write types section.")
 	flag.BoolVar(&cfg.Factories, "factories", false, "If 'types' is specified, write section for functions returning each type.")

--- a/cmd/goreadme/main.go
+++ b/cmd/goreadme/main.go
@@ -48,6 +48,7 @@ func init() {
 	flag.StringVar(&cfg.ImportPath, "import-path", "", "Override package import path.")
 	flag.StringVar(&cfg.Title, "title", "", "Override readme title. Default is package name.")
 	flag.BoolVar(&cfg.RecursiveSubPackages, "recursive", false, "Load docs recursively.")
+	flag.BoolVar(&cfg.Ellipsis, "ellipsis", true, "If 'types' is specified, replace types content with an ellipsis.")
 	flag.BoolVar(&cfg.Consts, "constants", false, "Write package constants section, and if 'types' is specified, also write per-type constants section.")
 	flag.BoolVar(&cfg.Vars, "variabless", false, "Write package variables section, and if 'types' is specified, also write per-type variables section.")
 	flag.BoolVar(&cfg.Functions, "functions", false, "Write functions section.")

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,11 @@
-module github.com/posener/goreadme
+module github.com/alexandregv/goreadme
 
 require (
 	github.com/golang/gddo v0.0.0-20200324184333-3c2cc9a6329d
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/posener/goaction v1.2.1
+	github.com/posener/goreadme v1.4.2
 	github.com/stretchr/testify v1.5.1
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 )

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,11 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/autogen v0.0.2/go.mod h1:23ND5WRzjjNM+lOMUvy4WudgDikSK3Sm0rmaXAfnIWo=
+github.com/posener/goaction v0.1.0/go.mod h1:HaHvM/qmQUIX/grEXhkfBJEC2AaUkyBNByJq7EGyT3Q=
 github.com/posener/goaction v1.2.1 h1:zOrQ52GhRdpZNjDBFale1QNwDoXbR6rrmnWYV2Be0ac=
 github.com/posener/goaction v1.2.1/go.mod h1:aHgsx8Q6UtebZBWRs8JiSCapjNTfPVqB2Mvi+0REtRQ=
+github.com/posener/goreadme v1.4.2 h1:wllVDVZiEZMstQxBTG/QCBxK/uGZSJomukc7n8uzgq0=
+github.com/posener/goreadme v1.4.2/go.mod h1:SvGw9nZP/KnxmtDx5vIqhET7GE8aHajWLCm4L6jYzOQ=
 github.com/posener/script v1.1.5 h1:su+9YHNlevT+Hlq2Xul5skh5kYDIBE+x4xu+5mLDT9o=
 github.com/posener/script v1.1.5/go.mod h1:Rg3ijooqulo05aGLyGsHoLmIOUzHUVK19WVgrYBPU/E=
 github.com/spf13/afero v0.0.0-20170901052352-ee1bd8ee15a1/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=

--- a/goreadme.go
+++ b/goreadme.go
@@ -144,6 +144,8 @@ type Config struct {
 	ImportPath string `json:"import_path"`
 	// Use the standard library comment parser introduced in Go 1.19 to generate the markdown output.
 	StdMarkdown bool `json:"std_markdown"`
+	// Ellipsis will replace types content with an ellipsis (`{ ... }`).
+	Ellipsis bool `json:"ellipsis"`
 	// Consts will make constants documentation to be added to the README.
 	// If Types is specified, constants for each type will also be added to the README.
 	Consts bool `json:"consts"`

--- a/internal/template/functions.md.gotmpl
+++ b/internal/template/functions.md.gotmpl
@@ -7,7 +7,7 @@
 
 ### func [{{ .Name }}]({{ urlOrName (index $.Files .Pos.File) }}#L{{ .Pos.Line }})
 
-{{ inlineCode .Decl.Text }}
+{{ gocodeEllipsis .Decl.Text }}
 
 {{ doc .Doc }}
 

--- a/internal/template/main.md.gotmpl
+++ b/internal/template/main.md.gotmpl
@@ -43,5 +43,5 @@
 {{ end }}
 {{ if config.Credit }}
 ---
-Readme created from Go doc with [goreadme](https://github.com/posener/goreadme)
+Readme created from Go doc with [goreadme](https://github.com/alexandregv/goreadme)
 {{ end }}

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -34,7 +34,7 @@ func funcs(cfg interface{}, options []markdown.Option) template.FuncMap {
 			return b.String()
 		},
 		"gocode": func(s string) string {
-			return "```golang\n" + s + "\n```\n"
+			return "```go\n" + s + "\n```\n"
 		},
 		"code": func(s string) string {
 			if !strings.HasSuffix(s, "\n") {

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -50,6 +50,11 @@ func funcs(cfg interface{}, options []markdown.Option) template.FuncMap {
 			s = r.ReplaceAllString(s, "{ ... }")
 			return "`" + s + "`"
 		},
+		"gocodeEllipsis": func(s string) string {
+			r := regexp.MustCompile(`{(?s).*}`)
+			s = r.ReplaceAllString(s, "{ ... }")
+			return "```go\n" + s + "\n```\n"
+		},
 		"importPath": func(p *doc.Package) string {
 			return p.ImportPath
 		},

--- a/internal/template/types.md.gotmpl
+++ b/internal/template/types.md.gotmpl
@@ -7,7 +7,7 @@
 
 ### type [{{ .Name }}]({{ urlOrName (index $.Files .Pos.File) }}#L{{ .Pos.Line }})
 
-{{ inlineCodeEllipsis .Decl.Text }}
+{{ gocodeEllipsis .Decl.Text }}
 
 {{ doc .Doc }}
 
@@ -27,7 +27,7 @@
 
 #### func [{{ .Name }}]({{ urlOrName (index $.Files .Pos.File) }}#L{{ .Pos.Line }})
 
-{{ inlineCodeEllipsis .Decl.Text }}
+{{ gocodeEllipsis .Decl.Text }}
 
 {{ doc .Doc }}
 
@@ -43,7 +43,7 @@
 
 #### func ({{ .Recv }}) [{{ .Name }}]({{ urlOrName (index $.Files .Pos.File) }}#L{{ .Pos.Line }})
 
-{{ inlineCodeEllipsis .Decl.Text }}
+{{ gocodeEllipsis .Decl.Text }}
 
 {{ doc .Doc }}
 

--- a/internal/template/types.md.gotmpl
+++ b/internal/template/types.md.gotmpl
@@ -7,7 +7,11 @@
 
 ### type [{{ .Name }}]({{ urlOrName (index $.Files .Pos.File) }}#L{{ .Pos.Line }})
 
+{{ if config.Ellipsis }}
 {{ gocodeEllipsis .Decl.Text }}
+{{ else }}
+{{ gocode .Decl.Text }}
+{{ end }}
 
 {{ doc .Doc }}
 


### PR DESCRIPTION
Adds a `-ellipsis` bool flag which allows to control wether you want to replace types content with an ellipsis or not.  
It defaults to true, to keep the current behavior.  

Example with `-ellipsis=false`:
```go
type Config struct { ... }
```
becomes
```go
type Config struct {
    Username      string `json:"username"`
    Password      string `json:"password"`
}
```