### PR TITLE
Add -render-type-content option to render full type content instead of an ellipsis (`{ ... }`)

### DIFF
--- a/cmd/goreadme/main.go
+++ b/cmd/goreadme/main.go
@@ -48,7 +48,7 @@ func init() {
 	flag.StringVar(&cfg.ImportPath, "import-path", "", "Override package import path.")
 	flag.StringVar(&cfg.Title, "title", "", "Override readme title. Default is package name.")
 	flag.BoolVar(&cfg.RecursiveSubPackages, "recursive", false, "Load docs recursively.")
-	flag.BoolVar(&cfg.Ellipsis, "ellipsis", true, "If 'types' is specified, replace types content with an ellipsis.")
+	flag.BoolVar(&cfg.RenderTypeContent, "render-type-content", false, "If 'types' is specified, render full type content.")
 	flag.BoolVar(&cfg.Consts, "constants", false, "Write package constants section, and if 'types' is specified, also write per-type constants section.")
 	flag.BoolVar(&cfg.Vars, "variabless", false, "Write package variables section, and if 'types' is specified, also write per-type variables section.")
 	flag.BoolVar(&cfg.Functions, "functions", false, "Write functions section.")

--- a/cmd/goreadme/main.go
+++ b/cmd/goreadme/main.go
@@ -48,6 +48,7 @@ func init() {
 	flag.StringVar(&cfg.ImportPath, "import-path", "", "Override package import path.")
 	flag.StringVar(&cfg.Title, "title", "", "Override readme title. Default is package name.")
 	flag.BoolVar(&cfg.RecursiveSubPackages, "recursive", false, "Load docs recursively.")
+	flag.BoolVar(&cfg.Ellipsis, "ellipsis", true, "If 'types' is specified, replace types content with an ellipsis.")
 	flag.BoolVar(&cfg.Consts, "constants", false, "Write package constants section, and if 'types' is specified, also write per-type constants section.")
 	flag.BoolVar(&cfg.Vars, "variabless", false, "Write package variables section, and if 'types' is specified, also write per-type variables section.")
 	flag.BoolVar(&cfg.Functions, "functions", false, "Write functions section.")

--- a/goreadme.go
+++ b/goreadme.go
@@ -144,8 +144,8 @@ type Config struct {
 	ImportPath string `json:"import_path"`
 	// Use the standard library comment parser introduced in Go 1.19 to generate the markdown output.
 	StdMarkdown bool `json:"std_markdown"`
-	// Ellipsis will replace types content with an ellipsis (`{ ... }`).
-	Ellipsis bool `json:"ellipsis"`
+	// RenderTypeContent will render fulll type content instead of an ellipsis (`{ ... }`).
+	RenderTypeContent bool `json:"render_type_content"`
 	// Consts will make constants documentation to be added to the README.
 	// If Types is specified, constants for each type will also be added to the README.
 	Consts bool `json:"consts"`

--- a/goreadme.go
+++ b/goreadme.go
@@ -144,6 +144,8 @@ type Config struct {
 	ImportPath string `json:"import_path"`
 	// Use the standard library comment parser introduced in Go 1.19 to generate the markdown output.
 	StdMarkdown bool `json:"std_markdown"`
+	// Ellipsis will replace types content with an ellipsis (`{ ... }`).
+	Ellipsis bool `json:"ellipsis"`
 	// Consts will make constants documentation to be added to the README.
 	// If Types is specified, constants for each type will also be added to the README.
 	Consts bool `json:"consts"`

--- a/internal/template/types.md.gotmpl
+++ b/internal/template/types.md.gotmpl
@@ -7,7 +7,11 @@
 
 ### type [{{ .Name }}]({{ urlOrName (index $.Files .Pos.File) }}#L{{ .Pos.Line }})
 
+{{ if config.Ellipsis }}
 {{ inlineCodeEllipsis .Decl.Text }}
+{{ else }}
+{{ gocode .Decl.Text }}
+{{ end }}
 
 {{ doc .Doc }}
 

--- a/internal/template/types.md.gotmpl
+++ b/internal/template/types.md.gotmpl
@@ -10,7 +10,7 @@
 {{ if config.RenderTypeContent }}
 {{ gocode .Decl.Text }}
 {{ else }}
-{{ inlineCodeEllipsis .Decl.Text }}
+{{ gocodeEllipsis .Decl.Text }}
 {{ end }}
 
 {{ doc .Doc }}

--- a/internal/template/types.md.gotmpl
+++ b/internal/template/types.md.gotmpl
@@ -7,10 +7,10 @@
 
 ### type [{{ .Name }}]({{ urlOrName (index $.Files .Pos.File) }}#L{{ .Pos.Line }})
 
-{{ if config.Ellipsis }}
-{{ inlineCodeEllipsis .Decl.Text }}
-{{ else }}
+{{ if config.RenderTypeContent }}
 {{ gocode .Decl.Text }}
+{{ else }}
+{{ inlineCodeEllipsis .Decl.Text }}
 {{ end }}
 
 {{ doc .Doc }}

--- a/testdata/pkg15_render_type_content/README.md
+++ b/testdata/pkg15_render_type_content/README.md
@@ -1,0 +1,39 @@
+# pkg15
+
+Package pkg15 is a testing package.
+
+## Types
+
+### type [ExampleType](/pkg.go#L5)
+
+```go
+type ExampleType struct {
+    ExportedVal int
+
+    ExampleInterface interface{}
+    // contains filtered or unexported fields
+}
+```
+
+ExampleType is a type
+
+### type [ExampleType2](/pkg.go#L21)
+
+```go
+type ExampleType2 struct {
+    ExampleInterface interface{}
+    // contains filtered or unexported fields
+}
+```
+
+ExampleType2 is a type with an array
+
+### type [ExampleTypeInt](/pkg.go#L27)
+
+```go
+type ExampleTypeInt struct {
+    // contains filtered or unexported fields
+}
+```
+
+ExampleTypeInt is a one-liner type

--- a/testdata/pkg15_render_type_content/go.mod
+++ b/testdata/pkg15_render_type_content/go.mod
@@ -1,0 +1,3 @@
+module pkg15
+
+go 1.15

--- a/testdata/pkg15_render_type_content/goreadme.json
+++ b/testdata/pkg15_render_type_content/goreadme.json
@@ -1,0 +1,4 @@
+{
+    "types": true,
+    "render_type_content": true
+}

--- a/testdata/pkg15_render_type_content/pkg.go
+++ b/testdata/pkg15_render_type_content/pkg.go
@@ -1,0 +1,27 @@
+// Package pkg15 is a testing package.
+package pkg15
+
+// ExampleType is a type
+type ExampleType struct {
+	ExportedVal      int
+	val              int
+	ExampleInterface interface{}
+}
+
+// ExampleTypeFactory is a factory function for ExampleType.
+func ExampleTypeFactory() ExampleType {
+	return ExampleType{1, 1, "test"}
+}
+
+// ExampleMethod is a method on ExampleType.
+func (e ExampleType) ExampleMethod() {
+}
+
+// ExampleType2 is a type with an array
+type ExampleType2 struct {
+	val              []int
+	ExampleInterface interface{}
+}
+
+// ExampleTypeInt is a one-liner type
+type ExampleTypeInt struct{ val int }


### PR DESCRIPTION
Adds a `-render-type-content` bool flag which allows to control wether you want to replace types content with an ellipsis or not.  
It defaults to false, to keep the current behavior.  

Example with `-render-type-content=true`:
```go
type Config struct { ... }
```
becomes
```go
type Config struct {
    Username      string `json:"username"`
    Password      string `json:"password"`
}
```