### PR TITLE
Allow customizing GoDoc URL and update godoc badge image

### DIFF
--- a/cmd/goreadme/main.go
+++ b/cmd/goreadme/main.go
@@ -47,6 +47,7 @@ var (
 func init() {
 	flag.StringVar(&cfg.ImportPath, "import-path", "", "Override package import path.")
 	flag.StringVar(&cfg.Title, "title", "", "Override readme title. Default is package name.")
+	flag.StringVar(&cfg.GoDocURL, "godoc-url", "https://pkg.go.dev", "Go Doc URL for GoDoc badge.")
 	flag.BoolVar(&cfg.RecursiveSubPackages, "recursive", false, "Load docs recursively.")
 	flag.BoolVar(&cfg.Consts, "constants", false, "Write package constants section, and if 'types' is specified, also write per-type constants section.")
 	flag.BoolVar(&cfg.Vars, "variabless", false, "Write package variables section, and if 'types' is specified, also write per-type variables section.")

--- a/goreadme.go
+++ b/goreadme.go
@@ -142,7 +142,7 @@ type Config struct {
 	// ImportPath is used to override the import path. For example: github.com/user/project,
 	// github.com/user/project/package or github.com/user/project/version.
 	ImportPath string `json:"import_path"`
-	// GoDocURL is the Go Doc URL used in the GoDoc Badge.
+	// GoDocURL is the Go Doc URL used in the GoDoc Badge. Default: https://pkg.go.dev.
 	GoDocURL string `json:"godoc_url"`
 	// Use the standard library comment parser introduced in Go 1.19 to generate the markdown output.
 	StdMarkdown bool `json:"std_markdown"`
@@ -268,6 +268,10 @@ func (r *GoReadme) get(ctx context.Context, name string) (*pkg, error) {
 
 	if override := r.config.ImportPath; override != "" {
 		p.ImportPath = override
+	}
+
+	if override := r.config.GoDocURL; override == "" {
+		r.config.GoDocURL = "https://pkg.go.dev"
 	}
 
 	pkg := &pkg{

--- a/goreadme.go
+++ b/goreadme.go
@@ -143,7 +143,7 @@ type Config struct {
 	// github.com/user/project/package or github.com/user/project/version.
 	ImportPath string `json:"import_path"`
 	// GoDocURL is the Go Doc URL used in the GoDoc Badge.
-	GoDocURL string `json:"go_doc_url"`
+	GoDocURL string `json:"godoc_url"`
 	// Use the standard library comment parser introduced in Go 1.19 to generate the markdown output.
 	StdMarkdown bool `json:"std_markdown"`
 	// Consts will make constants documentation to be added to the README.

--- a/goreadme.go
+++ b/goreadme.go
@@ -142,6 +142,8 @@ type Config struct {
 	// ImportPath is used to override the import path. For example: github.com/user/project,
 	// github.com/user/project/package or github.com/user/project/version.
 	ImportPath string `json:"import_path"`
+	// GoDocURL is the Go Doc URL used in the GoDoc Badge.
+	GoDocURL string `json:"go_doc_url"`
 	// Use the standard library comment parser introduced in Go 1.19 to generate the markdown output.
 	StdMarkdown bool `json:"std_markdown"`
 	// Consts will make constants documentation to be added to the README.

--- a/internal/template/main.md.gotmpl
+++ b/internal/template/main.md.gotmpl
@@ -10,7 +10,7 @@
 [![golangci](https://golangci.com/badges/{{importPath .Package}}.svg)](https://golangci.com/r/{{importPath .Package}})
 {{end -}}
 {{if config.Badges.GoDoc -}}
-[![GoDoc](https://img.shields.io/badge/pkg.go.dev-doc-blue)](http://pkg.go.dev/{{importPath .Package}})
+[![GoDoc](https://pkg.go.dev/badge/pkgsite/pkg.svg)]({{config.GoDocURL}}/{{importPath .Package}})
 {{end -}}
 {{if config.Badges.GoReportCard -}}
 [![Go Report Card](https://goreportcard.com/badge/{{importPath .Package}})](https://goreportcard.com/report/{{importPath .Package}})

--- a/testdata/pkg14_godoc_url/README.md
+++ b/testdata/pkg14_godoc_url/README.md
@@ -1,0 +1,5 @@
+# pkg14
+
+[![GoDoc](https://pkg.go.dev/badge/pkgsite/pkg.svg)](https://pkg.company.tld/./testdata/pkg14_godoc_url)
+
+Package pkg14 tests custom godoc_url.

--- a/testdata/pkg14_godoc_url/go.mod
+++ b/testdata/pkg14_godoc_url/go.mod
@@ -1,0 +1,1 @@
+module pkg14

--- a/testdata/pkg14_godoc_url/goreadme.json
+++ b/testdata/pkg14_godoc_url/goreadme.json
@@ -1,0 +1,6 @@
+{
+	"badges": {
+		"go_doc": true
+	},
+	"godoc_url": "https://pkg.company.tld"
+}

--- a/testdata/pkg14_godoc_url/pkg1.go
+++ b/testdata/pkg14_godoc_url/pkg1.go
@@ -1,0 +1,2 @@
+// Package pkg14 tests custom godoc_url.
+package pkg14

--- a/testdata/pkg4_badges/README.md
+++ b/testdata/pkg4_badges/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/./testdata/pkg4_badges.svg?branch=master)](https://travis-ci.org/./testdata/pkg4_badges)
 [![codecov](https://codecov.io/gh/./testdata/pkg4_badges/branch/master/graph/badge.svg)](https://codecov.io/gh/./testdata/pkg4_badges)
 [![golangci](https://golangci.com/badges/./testdata/pkg4_badges.svg)](https://golangci.com/r/./testdata/pkg4_badges)
-[![GoDoc](https://img.shields.io/badge/pkg.go.dev-doc-blue)](http://pkg.go.dev/./testdata/pkg4_badges)
+[![GoDoc](https://pkg.go.dev/badge/pkgsite/pkg.svg)](https://pkg.go.dev/./testdata/pkg4_badges)
 [![Go Report Card](https://goreportcard.com/badge/./testdata/pkg4_badges)](https://goreportcard.com/report/./testdata/pkg4_badges)
 
 Package pkg4 tests badges.


### PR DESCRIPTION
With this PR the GoDoc URL (default https://pkg.go.dev) can now be customized, useful when you host your own instance of [pkgsite](https://pkg.go.dev/golang.org/x/pkgsite).

I also updated the GoDoc badge image with a up-to-date one (godoc.org -> pkg.go.dev).