### PR TITLE
Add pre-commit support

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: goreadme
+  name: goreadme
+  description: Write README.md from go doc
+  entry: env README_FILE=README.md goreadme
+  language: golang
+  pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -54,6 +54,28 @@ $ GO111MODULE=on go get github.com/posener/goreadme/cmd/goreadme
 $ goreadme -h
 ```
 
+## Pre-Commit hook
+
+goreadme can also be used as a pre-commit hook, acting before each commit is made.
+
+1. Install pre-commit from [https://pre-commit.com/#install](https://pre-commit.com/#install)
+2. Create a `.pre-commit-config.yaml` file at the root of your repository with the following content:
+
+```go
+repos:
+  - repo: [https://github.com/posener/goreadme](https://github.com/posener/goreadme)
+    rev: v1.4.2 # Use the latest ref
+    hooks:
+      - id: goreadme
+        entry: env README_FILE=README.md goreadme
+        args: ['-badge-goreadme=true', '-badge-godoc=true']
+```
+
+3. Change README_FILE to your file name and add any flags you need in `args`.
+4. Auto-update the config to the latest repos' versions by executing `pre-commit autoupdate`
+5. Install with `pre-commit install`
+6. Now you're all set! Try a commit, see the README being updated (if relevant), and continue your commit.
+
 ## Why Should You Use It
 
 Both Go doc and readme files are important. Go doc to be used by your user's library, and README

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ jobs:
             GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
 ```
 
-Use as a command line tool
+## Use as a command line tool
 
 ```go
 $ GO111MODULE=on go get github.com/posener/goreadme/cmd/goreadme

--- a/goreadme.go
+++ b/goreadme.go
@@ -39,7 +39,7 @@
 //	            # Optional: Token allows goreadme to comment the PR with diff preview.
 //	            GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
 //
-// Use as a command line tool
+// # Use as a command line tool
 //
 //	$ GO111MODULE=on go get github.com/posener/goreadme/cmd/goreadme
 //	$ goreadme -h

--- a/goreadme.go
+++ b/goreadme.go
@@ -44,6 +44,26 @@
 //	$ GO111MODULE=on go get github.com/posener/goreadme/cmd/goreadme
 //	$ goreadme -h
 //
+// # Pre-Commit hook
+//
+// goreadme can also be used as a pre-commit hook, acting before each commit is made.
+//
+// 1. Install pre-commit from https://pre-commit.com/#install
+// 2. Create a `.pre-commit-config.yaml` file at the root of your repository with the following content:
+//
+//	repos:
+//	  - repo: https://github.com/posener/goreadme
+//	    rev: v1.4.2 # Use the latest ref
+//	    hooks:
+//	      - id: goreadme
+//	        entry: env README_FILE=README.md goreadme
+//	        args: ['-badge-goreadme=true', '-badge-godoc=true']
+//
+// 3. Change README_FILE to your file name and add any flags you need in `args`.
+// 4. Auto-update the config to the latest repos' versions by executing `pre-commit autoupdate`
+// 5. Install with `pre-commit install`
+// 6. Now you're all set! Try a commit, see the README being updated (if relevant), and continue your commit.
+//
 // # Why Should You Use It
 //
 // Both Go doc and readme files are important. Go doc to be used by your user's library, and README


### PR DESCRIPTION
[pre-commit](https://github.com/pre-commit/pre-commit) is "A framework for managing and maintaining multi-language pre-commit hooks", so kinda like a local CI. It's a popular tool with a lot of community-made hooks.
I thought it would be very handy to have pre-commit support in goreadme, allowing to rewrite the readme each time the doc is changed, even before pushing.

The PR only consists of a new file used by pre-commit, and the new instructions in README. It has no impact on goreadme itself.  
I tested it on a private repo and it works well.